### PR TITLE
Fix openai error exception path

### DIFF
--- a/microchain/models/generators.py
+++ b/microchain/models/generators.py
@@ -34,7 +34,7 @@ class OpenAIChatGenerator:
                 stop=stop,
                 timeout=self.timeout
             )
-        except openai.error.OpenAIError as e:
+        except openai.OpenAIError as e:
             print(colored(f"Error: {e}", "red"))
             return "Error: timeout"
         
@@ -76,7 +76,7 @@ class OpenAITextGenerator:
                 top_p=self.top_p,
                 stop=stop
             )
-        except openai.error.OpenAIError as e:
+        except openai.OpenAIError as e:
             print(colored(f"Error: {e}", "red"))
             return "Error: timeout"
         


### PR DESCRIPTION
With openai package version `==1.16.2`, I'm seeing the error:

```
  File "/Users/evan/dev/prediction-market-agent/.venv/lib/python3.10/site-packages/microchain/models/generators.py", line 37, in __call__
    except openai.error.OpenAIError as e:
AttributeError: module 'openai' has no attribute 'error'
```

Fixing here by changing the path from `openai.error.OpenAIError` -> `openai.OpenAIError`