### PR TITLE
Add TokenTracker to track cost of calling `agent.run`

### DIFF
--- a/microchain/models/generators.py
+++ b/microchain/models/generators.py
@@ -1,5 +1,6 @@
 from termcolor import colored
 
+
 class TokenTracker:
     def __init__(self):
         self.prompt_tokens = 0
@@ -10,6 +11,7 @@ class TokenTracker:
         self.completion_tokens += usage.completion_tokens
 
     def get_total_cost(self, model):
+        # From https://openai.com/pricing
         if model in ["gpt-4-0125-preview", "gpt-4-1106-preview", "gpt-4-turbo-preview"]:
             costs = {"prompt": 1e-05, "completion": 3e-05}
         elif model == "gpt-3.5-turbo-0125":
@@ -18,17 +20,32 @@ class TokenTracker:
             print(f"Unsupported {model}")
             return 0
 
-        return self.prompt_tokens * costs["prompt"] + self.completion_tokens * costs["completion"]
-
+        return (
+            self.prompt_tokens * costs["prompt"]
+            + self.completion_tokens * costs["completion"]
+        )
 
 
 class OpenAIChatGenerator:
-    def __init__(self, *, model, api_key, api_base, temperature=0.9, top_p=1, max_tokens=512, timeout=30, token_tracker=TokenTracker()):
+    def __init__(
+        self,
+        *,
+        model,
+        api_key,
+        api_base,
+        temperature=0.9,
+        top_p=1,
+        max_tokens=512,
+        timeout=30,
+        token_tracker=TokenTracker(),
+    ):
         try:
             import openai
         except ImportError:
-            raise ImportError("Please install OpenAI python library using pip install openai")
-    
+            raise ImportError(
+                "Please install OpenAI python library using pip install openai"
+            )
+
         self.model = model
         self.api_key = api_key
         self.api_base = api_base
@@ -38,15 +55,17 @@ class OpenAIChatGenerator:
         self.timeout = timeout
         self.token_tracker = token_tracker
 
-        self.client = openai.OpenAI(
-            api_key=self.api_key,
-            base_url=self.api_base
-        )
-    
+        self.client = openai.OpenAI(api_key=self.api_key, base_url=self.api_base)
+
     def __call__(self, messages, stop=None):
         import openai
-        oai_error = openai.error.OpenAIError if hasattr(openai, "error") else openai.OpenAIError
-        assert isinstance(messages, list), "messages must be a list of messages https://platform.openai.com/docs/guides/text-generation/chat-completions-api"
+
+        oai_error = (
+            openai.error.OpenAIError if hasattr(openai, "error") else openai.OpenAIError
+        )
+        assert isinstance(
+            messages, list
+        ), "messages must be a list of messages https://platform.openai.com/docs/guides/text-generation/chat-completions-api"
 
         try:
             response = self.client.chat.completions.create(
@@ -56,7 +75,7 @@ class OpenAIChatGenerator:
                 max_tokens=self.max_tokens,
                 top_p=self.top_p,
                 stop=stop,
-                timeout=self.timeout
+                timeout=self.timeout,
             )
         except oai_error as e:
             print(colored(f"Error: {e}", "red"))
@@ -68,20 +87,27 @@ class OpenAIChatGenerator:
             self.token_tracker.update_from_usage(response.usage)
 
         return output
-    
+
     def print_usage(self):
         if self.token_tracker:
-            print(f"Usage: prompt={self.token_tracker.prompt_tokens}, completion={self.token_tracker.completion_tokens}, cost=${self.token_tracker.get_total_cost(self.model):.2f}")
+            print(
+                f"Usage: prompt={self.token_tracker.prompt_tokens}, completion={self.token_tracker.completion_tokens}, cost=${self.token_tracker.get_total_cost(self.model):.2f}"
+            )
         else:
             print("Token tracker not available")
 
+
 class OpenAITextGenerator:
-    def __init__(self, *, model, api_key, api_base, temperature=0.9, top_p=1, max_tokens=512):
+    def __init__(
+        self, *, model, api_key, api_base, temperature=0.9, top_p=1, max_tokens=512
+    ):
         try:
             import openai
         except ImportError:
-            raise ImportError("Please install OpenAI python library using pip install openai")
-    
+            raise ImportError(
+                "Please install OpenAI python library using pip install openai"
+            )
+
         self.model = model
         self.api_key = api_key
         self.api_base = api_base
@@ -89,15 +115,17 @@ class OpenAITextGenerator:
         self.top_p = top_p
         self.max_tokens = max_tokens
 
-        self.client = openai.OpenAI(
-            api_key=self.api_key,
-            base_url=self.api_base
-        )
-    
+        self.client = openai.OpenAI(api_key=self.api_key, base_url=self.api_base)
+
     def __call__(self, prompt, stop=None):
         import openai
-        oai_error = openai.error.OpenAIError if hasattr(openai, "error") else openai.OpenAIError
-        assert isinstance(prompt, str), "prompt must be a string https://platform.openai.com/docs/guides/text-generation/chat-completions-api"
+
+        oai_error = (
+            openai.error.OpenAIError if hasattr(openai, "error") else openai.OpenAIError
+        )
+        assert isinstance(
+            prompt, str
+        ), "prompt must be a string https://platform.openai.com/docs/guides/text-generation/chat-completions-api"
 
         try:
             response = self.client.completions.create(
@@ -106,13 +134,12 @@ class OpenAITextGenerator:
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
                 top_p=self.top_p,
-                stop=stop
+                stop=stop,
             )
         except oai_error as e:
             print(colored(f"Error: {e}", "red"))
             return "Error: timeout"
-        
+
         output = response.choices[0].text.strip()
 
         return output
-    

--- a/microchain/models/generators.py
+++ b/microchain/models/generators.py
@@ -1,6 +1,5 @@
 from termcolor import colored
 
-
 class TokenTracker:
     def __init__(self):
         self.prompt_tokens = 0
@@ -20,32 +19,17 @@ class TokenTracker:
             print(f"Unsupported {model}")
             return 0
 
-        return (
-            self.prompt_tokens * costs["prompt"]
-            + self.completion_tokens * costs["completion"]
-        )
+        return self.prompt_tokens * costs["prompt"] + self.completion_tokens * costs["completion"]
+
 
 
 class OpenAIChatGenerator:
-    def __init__(
-        self,
-        *,
-        model,
-        api_key,
-        api_base,
-        temperature=0.9,
-        top_p=1,
-        max_tokens=512,
-        timeout=30,
-        token_tracker=TokenTracker(),
-    ):
+    def __init__(self, *, model, api_key, api_base, temperature=0.9, top_p=1, max_tokens=512, timeout=30, token_tracker=TokenTracker()):
         try:
             import openai
         except ImportError:
-            raise ImportError(
-                "Please install OpenAI python library using pip install openai"
-            )
-
+            raise ImportError("Please install OpenAI python library using pip install openai")
+    
         self.model = model
         self.api_key = api_key
         self.api_base = api_base
@@ -55,17 +39,15 @@ class OpenAIChatGenerator:
         self.timeout = timeout
         self.token_tracker = token_tracker
 
-        self.client = openai.OpenAI(api_key=self.api_key, base_url=self.api_base)
-
+        self.client = openai.OpenAI(
+            api_key=self.api_key,
+            base_url=self.api_base
+        )
+    
     def __call__(self, messages, stop=None):
         import openai
-
-        oai_error = (
-            openai.error.OpenAIError if hasattr(openai, "error") else openai.OpenAIError
-        )
-        assert isinstance(
-            messages, list
-        ), "messages must be a list of messages https://platform.openai.com/docs/guides/text-generation/chat-completions-api"
+        oai_error = openai.error.OpenAIError if hasattr(openai, "error") else openai.OpenAIError
+        assert isinstance(messages, list), "messages must be a list of messages https://platform.openai.com/docs/guides/text-generation/chat-completions-api"
 
         try:
             response = self.client.chat.completions.create(
@@ -75,7 +57,7 @@ class OpenAIChatGenerator:
                 max_tokens=self.max_tokens,
                 top_p=self.top_p,
                 stop=stop,
-                timeout=self.timeout,
+                timeout=self.timeout
             )
         except oai_error as e:
             print(colored(f"Error: {e}", "red"))
@@ -87,27 +69,20 @@ class OpenAIChatGenerator:
             self.token_tracker.update_from_usage(response.usage)
 
         return output
-
+    
     def print_usage(self):
         if self.token_tracker:
-            print(
-                f"Usage: prompt={self.token_tracker.prompt_tokens}, completion={self.token_tracker.completion_tokens}, cost=${self.token_tracker.get_total_cost(self.model):.2f}"
-            )
+            print(f"Usage: prompt={self.token_tracker.prompt_tokens}, completion={self.token_tracker.completion_tokens}, cost=${self.token_tracker.get_total_cost(self.model):.2f}")
         else:
             print("Token tracker not available")
 
-
 class OpenAITextGenerator:
-    def __init__(
-        self, *, model, api_key, api_base, temperature=0.9, top_p=1, max_tokens=512
-    ):
+    def __init__(self, *, model, api_key, api_base, temperature=0.9, top_p=1, max_tokens=512):
         try:
             import openai
         except ImportError:
-            raise ImportError(
-                "Please install OpenAI python library using pip install openai"
-            )
-
+            raise ImportError("Please install OpenAI python library using pip install openai")
+    
         self.model = model
         self.api_key = api_key
         self.api_base = api_base
@@ -115,17 +90,15 @@ class OpenAITextGenerator:
         self.top_p = top_p
         self.max_tokens = max_tokens
 
-        self.client = openai.OpenAI(api_key=self.api_key, base_url=self.api_base)
-
+        self.client = openai.OpenAI(
+            api_key=self.api_key,
+            base_url=self.api_base
+        )
+    
     def __call__(self, prompt, stop=None):
         import openai
-
-        oai_error = (
-            openai.error.OpenAIError if hasattr(openai, "error") else openai.OpenAIError
-        )
-        assert isinstance(
-            prompt, str
-        ), "prompt must be a string https://platform.openai.com/docs/guides/text-generation/chat-completions-api"
+        oai_error = openai.error.OpenAIError if hasattr(openai, "error") else openai.OpenAIError
+        assert isinstance(prompt, str), "prompt must be a string https://platform.openai.com/docs/guides/text-generation/chat-completions-api"
 
         try:
             response = self.client.completions.create(
@@ -134,12 +107,13 @@ class OpenAITextGenerator:
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
                 top_p=self.top_p,
-                stop=stop,
+                stop=stop
             )
         except oai_error as e:
             print(colored(f"Error: {e}", "red"))
             return "Error: timeout"
-
+        
         output = response.choices[0].text.strip()
 
         return output
+    


### PR DESCRIPTION
Running function calling agents gets expensive, so it's good to be able to track costs.

Example usage:
```
generator = OpenAIChatGenerator(
    model="gpt-4-turbo-preview",
    api_key=os.getenv("OPENAI_API_KEY"),
    api_base="https://api.openai.com/v1",
    temperature=0.7,
)
llm = LLM(generator=generator)
agent = Agent(llm=llm, engine=engine)
...
agent.run(iterations=10)
generator.print_usage()
```
gives:
```
Usage: prompt=4332, completion=177, cost=$0.05
```