### PR TITLE
Add ability to interleave `agent.run` calls with input from the user

### DIFF
--- a/microchain/engine/agent.py
+++ b/microchain/engine/agent.py
@@ -111,11 +111,10 @@ class Agent:
 
         if not resume:
             print(colored(f"prompt:\n{self.prompt}", "blue"))
-            print(colored(f"Running {iterations} iterations", "green"))
-
             self.reset()
             self.build_initial_messages()
 
+        print(colored(f"Running {iterations} iterations", "green"))
         for it in range(iterations):
             if self.do_stop:
                 break

--- a/microchain/engine/agent.py
+++ b/microchain/engine/agent.py
@@ -18,6 +18,23 @@ class Agent:
         self.history = []
         self.do_stop = False
 
+    def execute_command(self, command: str):
+        result, output = self.engine.execute(command)
+        if result == FunctionResult.ERROR:
+            raise Exception(f"Your command ({command}) contains an error. output={output}")
+
+        print(colored(f">> {command}", "blue"))
+        print(colored(f"{output}", "green"))
+
+        self.history.append(dict(
+            role="assistant",
+            content=command
+        ))
+        self.history.append(dict(
+            role="user",
+            content=output
+        ))
+
     def build_initial_messages(self):
         self.history = [
             dict(
@@ -26,21 +43,7 @@ class Agent:
             ),
         ]
         for command in self.bootstrap:
-            result, output = self.engine.execute(command)
-            if result == FunctionResult.ERROR:
-                raise Exception(f"Your bootstrap commands contain an error. output={output}")
-
-            print(colored(f">> {command}", "blue"))
-            print(colored(f"{output}", "green"))
-
-            self.history.append(dict(
-                role="assistant",
-                content=command
-            ))
-            self.history.append(dict(
-                role="user",
-                content=output
-            ))
+            self.execute_command(command)
             
     def clean_reply(self, reply):
         reply = reply.replace("\_", "_")
@@ -102,15 +105,16 @@ class Agent:
             output=output,
         )
 
-    def run(self, iterations=10):
+    def run(self, iterations=10, resume=False):
         if self.prompt is None:
             raise ValueError("You must set a prompt before running the agent")
 
-        print(colored(f"prompt:\n{self.prompt}", "blue"))
-        print(colored(f"Running {iterations} iterations", "green"))
+        if not resume:
+            print(colored(f"prompt:\n{self.prompt}", "blue"))
+            print(colored(f"Running {iterations} iterations", "green"))
 
-        self.reset()
-        self.build_initial_messages()
+            self.reset()
+            self.build_initial_messages()
 
         for it in range(iterations):
             if self.do_stop:


### PR DESCRIPTION
Two new features:

- New method `Agent.execute_command`. i.e. bootstrapping the agent, but not necessarily just at the start
- New argument, `resume` on `Agent.run` method. Doesn't wipe agent history and start again.

Example usage of the new features

```
agent = Agent(llm=LLM(generator=generator), engine=engine)
agent.prompt = f"Reason step by step. {engine.help}"

# Run a number of steps autonomously
agent.run(iterations=2)
# Get input from the user
agent.execute_command(...)
# Continue running autonomously
agent.run(iterations=3, resume=True)
```