### PR TITLE
Add optional system prompt and make prompt optional as well

### DIFF
--- a/microchain/engine/agent.py
+++ b/microchain/engine/agent.py
@@ -39,18 +39,18 @@ class Agent:
 
     def build_initial_messages(self):
         self.history = []
-        if self.prompt:
-            self.history.append(
-                dict(
-                    role="user",
-                    content=self.prompt
-                ),
-            )
         if self.system_prompt:
             self.history.append(
                 dict(
                     role="system",
                     content=self.system_prompt
+                ),
+            )
+        if self.prompt:
+            self.history.append(
+                dict(
+                    role="user",
+                    content=self.prompt
                 ),
             )
         for command in self.bootstrap:

--- a/microchain/engine/agent.py
+++ b/microchain/engine/agent.py
@@ -7,6 +7,7 @@ class Agent:
         self.engine = engine
         self.max_tries = 10
         self.prompt = None
+        self.system_prompt = None
         self.bootstrap = []
         self.do_stop = False
         self.on_iteration_end = on_iteration_end
@@ -37,12 +38,21 @@ class Agent:
         ))
 
     def build_initial_messages(self):
-        self.history = [
-            dict(
-                role="user",
-                content=self.prompt
-            ),
-        ]
+        self.history = []
+        if self.prompt:
+            self.history.append(
+                dict(
+                    role="user",
+                    content=self.prompt
+                ),
+            )
+        if self.system_prompt:
+            self.history.append(
+                dict(
+                    role="system",
+                    content=self.system_prompt
+                ),
+            )
         for command in self.bootstrap:
             self.execute_command(command)
             


### PR DESCRIPTION
Hi, we are using this project with @evangriffiths, and so far, it's super cool!

Adding two new features here:

1. Append `self.prompt` to `history` in `build_initial_messages` only if it's available.
2. Add also `self.system_prompt`, used in the same way as `self.prompt`, but it appends a system message.