### PR TITLE
Fix if only system prompt is provided

### DIFF
--- a/microchain/engine/agent.py
+++ b/microchain/engine/agent.py
@@ -117,11 +117,11 @@ class Agent:
         )
 
     def run(self, iterations=10, resume=False):
-        if self.prompt is None:
+        if self.prompt is None and self.system_prompt is None:
             raise ValueError("You must set a prompt before running the agent")
 
         if not resume:
-            print(colored(f"prompt:\n{self.prompt}", "blue"))
+            print(colored(f"prompt:\n{self.prompt},system_prompt:\n{self.system_prompt}", "blue"))
             self.reset()
             self.build_initial_messages()
 


### PR DESCRIPTION
Hi, sorry, but I introduced a bug in the last PR, where if only `system_prompt` is provided (but no `prompt`), agent fails to run. Could you look at this and do a release, please?