### PR TITLE
Don't swallow exception from inside a function 

### DIFF
--- a/microchain/__init__.py
+++ b/microchain/__init__.py
@@ -6,4 +6,4 @@ from microchain.models.llm import LLM
 from microchain.engine.function import Function, FunctionResult
 from microchain.engine.engine import Engine
 
-from microchain.engine.agent import Agent
+from microchain.engine.agent import Agent, StepOutput

--- a/microchain/engine/agent.py
+++ b/microchain/engine/agent.py
@@ -1,7 +1,15 @@
+from dataclasses import dataclass
 from termcolor import colored
 
 from microchain.engine.function import FunctionResult
 
+
+@dataclass
+class StepOutput:
+    abort: bool
+    reply: str
+    output: str
+    result: FunctionResult
 
 class Agent:
     def __init__(self, llm, engine, on_iteration_start=None, on_iteration_step=None, on_iteration_end=None, stop_list=["\n"]):
@@ -121,7 +129,7 @@ class Agent:
                 print(colored(output, "green"))
                 break
         
-        return dict(
+        return StepOutput(
             abort=abort,
             reply=reply,
             output=output,
@@ -153,16 +161,16 @@ class Agent:
             step_output = self.step(transient_history)
             if self.on_iteration_step is not None: self.on_iteration_step(self, step_output)
 
-            if step_output["abort"]:
+            if step_output.abort:
                 break
 
             self.history.append(dict(
                 role="assistant",
-                content=step_output["reply"]
+                content=step_output.reply
             ))
             self.history.append(dict(
                 role="user",
-                content=step_output["output"]
+                content=step_output.output
             ))
             if self.on_iteration_end is not None:
                 self.on_iteration_end(self)

--- a/microchain/engine/agent.py
+++ b/microchain/engine/agent.py
@@ -125,6 +125,7 @@ class Agent:
             abort=abort,
             reply=reply,
             output=output,
+            result=result,
         )
 
     def run(self, iterations=10, resume=False, transient_history=[]):

--- a/microchain/engine/agent.py
+++ b/microchain/engine/agent.py
@@ -169,4 +169,3 @@ class Agent:
             
             it = it + 1
         print(colored(f"Finished {iterations} iterations", "green"))
-        return step_output

--- a/microchain/engine/agent.py
+++ b/microchain/engine/agent.py
@@ -1,5 +1,7 @@
-from microchain.engine.function import Function, FunctionResult
 from termcolor import colored
+
+from microchain.engine.function import FunctionResult
+
 
 class Agent:
     def __init__(self, llm, engine, on_iteration_end=None):
@@ -133,3 +135,4 @@ class Agent:
                 self.on_iteration_end(self)
             
         print(colored(f"Finished {iterations} iterations", "green"))
+        return step_output

--- a/microchain/engine/function.py
+++ b/microchain/engine/function.py
@@ -62,9 +62,16 @@ class Function:
         try:
             return FunctionResult.SUCCESS, str(self.__call__(*args, **kwargs))
         except Exception as e:
+            stacktrace = ''.join(traceback.TracebackException.from_exception(e).format())
             print(colored(f"Exception in Function call {e}", "red"))
-            print(colored(''.join(traceback.TracebackException.from_exception(e).format()), "red"))
-            return FunctionResult.ERROR, self.error
+            print(colored(stacktrace, "red"))
+
+            if type(e) in [TypeError, SyntaxError]:
+                # Catch remaining errors from a bad call
+                return FunctionResult.ERROR, self.error
+            else:
+                # Return the stacktrace of the error from inside the function
+                return FunctionResult.ERROR, f"Error inside function call: {stacktrace}"
 
     def __call__(self, command):
         raise NotImplementedError


### PR DESCRIPTION
1. Return `result` from `Agent.step` so the user can easily determine if there was an error, as apposed to aborting from a `Stop` call
2. Return the stacktrace of an exception if it's from inside the function, instead of swallowing the exception and returning `function.error`
3. Have `Agent.step` return a dataclass instead of a dict to make it more friendly when using in projects that use strict typing